### PR TITLE
Revolyssup/forward auth fix

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -299,8 +299,10 @@ function _M.get_body(max_size, ctx)
             return nil, "HTTP2/HTTP3 request without a Content-Length header"
         end
     end
+    local var = ctx and ctx.var or ngx.var
+    log.warn("reading started...", var.server_protocol)
     req_read_body()
-
+    log.warn("reading ended...")
     local req_body = req_get_body_data()
     if req_body then
         local ok, err = check_size(#req_body, max_size)


### PR DESCRIPTION
log from: https://github.com/Revolyssup/apisix/pull/12/files#diff-0073cfbea9a5a75144a290a1940a3046d0c24e811bd34fcc93838f041aec859aR405




### logs
```log
2025/07/06 23:56:00 [info] 190999#190999: *19 [lua] ai.lua:82: match(): route cache key: /ping, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *19 [lua] radixtree_host_uri.lua:161: orig_router_http_matching(): route match mode: radixtree_host_uri, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *19 [lua] init.lua:660: http_access_phase(): matched route: {"orig_modifiedIndex":2935,"value":{"create_time":1750405033,"status":1,"plugins":{"forward-auth":{"client_headers":["Location"],"status_on_error":403,"allow_degradation":false,"keepalive_pool":5,"ssl_verify":true,"timeout":60000,"keepalive_timeout":60000,"keepalive":true,"uri":"http://127.0.0.1:1984/auth","request_method":"POST","request_headers":{},"upstream_headers":["X-User-ID"]},"proxy-rewrite":{"uri":"/echo","use_real_request_uri_unsafe":false}},"upstream_id":"u1","uri":"/ping","priority":0,"id":"3","update_time":1751826356},"has_domain":false,"clean_handlers":{},"modifiedIndex":2935,"key":"/apisix/routes/3","createdIndex":4}, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [warn] 190999#190999: *19 [lua] forward-auth.lua:140: phase_func(): URI: http://127.0.0.1:1984/auth, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [warn] 190999#190999: *19 [lua] forward-auth.lua:148: phase_func(): hostport 127.0.0.11984/auth, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [warn] 190999#190999: *19 [lua] forward-auth.lua:161: phase_func(): PARAMS: {
  body = <function 1>,
  headers = {
    ["Content-Length"] = "24",
    ["X-Forwarded-For"] = "127.0.0.1",
    ["X-Forwarded-Host"] = "localhost",
    ["X-Forwarded-Method"] = "POST",
    ["X-Forwarded-Proto"] = "http",
    ["X-Forwarded-Uri"] = "/ping"
  },
  keepalive = true,
  keepalive_pool = 5,
  keepalive_timeout = 1000,
  method = "POST",
  path = "/auth",
  ssl_verify = true
}, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *41 [lua] ai.lua:79: match(): route match mode: ai_match, client: 127.0.0.1, server: localhost, request: "POST /auth HTTP/1.1", host: "127.0.0.1:1984"
2025/07/06 23:56:00 [info] 190999#190999: *41 [lua] ai.lua:82: match(): route cache key: /auth, client: 127.0.0.1, server: localhost, request: "POST /auth HTTP/1.1", host: "127.0.0.1:1984"
2025/07/06 23:56:00 [info] 190999#190999: *41 [lua] radixtree_host_uri.lua:161: orig_router_http_matching(): route match mode: radixtree_host_uri, client: 127.0.0.1, server: localhost, request: "POST /auth HTTP/1.1", host: "127.0.0.1:1984"
2025/07/06 23:56:00 [info] 190999#190999: *41 [lua] init.lua:660: http_access_phase(): matched route: {"orig_modifiedIndex":2931,"value":{"create_time":1751435139,"status":1,"id":"auth","uri":"/auth","priority":0,"plugins":{"serverless-pre-function":{"phase":"rewrite","functions":["return function(conf, ctx)\n                                        local core = require(\"apisix.core\");\n                                        if core.request.header(ctx, \"Authorization\") == \"111\" then\n                                            core.response.exit(200);\n                                        end\n                                    end","return function(conf, ctx)\n                                        local core = require(\"apisix.core\");\n                                        if core.request.header(ctx, \"Authorization\") == \"222\" then\n                                            core.response.set_header(\"X-User-ID\", \"i-am-an-user\");\n                                            core.response.exit(200);\n                                        end\n                                    end","return function(conf, ctx)\n                                        local core = require(\"apisix.core\");\n                                        if core.request.header(ctx, \"Authorization\") == \"333\" then\n                                            core.response.set_header(\"Location\", \"http://example.com/auth\");\n                                            core.response.exit(403);\n                                        end\n                                    end","return function(conf, ctx)\n                                        local core = require(\"apisix.core\");\n                                        if core.request.header(ctx, \"Authorization\") == \"444\" then\n                                            core.response.exit(403, core.request.headers(ctx));\n                                        end\n                                    end","                                        return function(conf, ctx)\n                                        local core = require(\"apisix.core\")\n                                        if core.request.get_method() == \"POST\" then\n                                            if core.request.header(ctx, \"Authorization\") == \"large-body\" then\n                                                core.response.set_header(\"X-User-ID\", \"large-body\")\n                                                core.response.exit(200)\n                                            end\n                                            if core.request.header(ctx, \"Authorization\") == \"i-am-not-an-user-large-body\" then\n                                                core.response.exit(403)\n                                            end\n                                        end\n                                    end","return function(conf, ctx)\n                                        local core = require(\"apisix.core\")\n                                        if core.request.get_method() == \"POST\" then\n                                            core.log.warn(\"START\")\n                                           local req_body, err = core.request.get_body()\n                                           if err then\n                                               core.response.exit(400)\n                                           end\n                                           core.log.warn(\"END\")\n                                           if req_body then\n                                               local data, err = core.json.decode(req_body)\n                                               if err then\n                                                   core.response.exit(400)\n                                               end\n                                               if data[\"authorization\"] == \"555\" then\n                                                   core.response.set_header(\"X-User-ID\", \"i-am-an-user\")\n                                  
2025/07/06 23:56:00 [warn] 190999#190999: *41 [lua] [string "return function(conf, ctx)..."]:4: func(): START, client: 127.0.0.1, server: localhost, request: "POST /auth HTTP/1.1", host: "127.0.0.1:1984"
2025/07/06 23:56:00 [warn] 190999#190999: *41 [lua] request.lua:303: get_body(): reading started...HTTP/1.1, client: 127.0.0.1, server: localhost, request: "POST /auth HTTP/1.1", host: "127.0.0.1:1984"
2025/07/06 23:56:00 [warn] 190999#190999: *41 [lua] request.lua:305: get_body(): reading ended..., client: 127.0.0.1, server: localhost, request: "POST /auth HTTP/1.1", host: "127.0.0.1:1984"
2025/07/06 23:56:00 [warn] 190999#190999: *41 [lua] [string "return function(conf, ctx)..."]:9: func(): END, client: 127.0.0.1, server: localhost, request: "POST /auth HTTP/1.1", host: "127.0.0.1:1984"
2025/07/06 23:56:00 [warn] 190999#190999: *19 [lua] forward-auth.lua:169: phase_func(): status is200, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [warn] 190999#190999: *19 [lua] forward-auth.lua:171: phase_func(): body is, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *19 [lua] upstream.lua:654: get_by_id(): parsed upstream: {"value":{"create_time":1751435139,"type":"roundrobin","id":"u1","update_time":1751826356,"hash_on":"vars","pass_host":"pass","nodes":[{"port":1984,"weight":1,"host":"127.0.0.1"}],"parent":{"value":"table: 0x766599661220","has_domain":false,"clean_handlers":{},"modifiedIndex":2930,"key":"/apisix/upstreams/u1","createdIndex":885},"scheme":"http"},"has_domain":false,"clean_handlers":"table: 0x76659762f988","modifiedIndex":2930,"key":"/apisix/upstreams/u1","createdIndex":885}, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *19 [lua] balancer.lua:195: pick_server(): route: {"orig_modifiedIndex":2935,"value":{"create_time":1750405033,"status":1,"plugins":{"forward-auth":{"client_headers":["Location"],"status_on_error":403,"allow_degradation":false,"keepalive_pool":5,"ssl_verify":true,"timeout":60000,"keepalive_timeout":60000,"keepalive":true,"uri":"http://127.0.0.1:1984/auth","request_method":"POST","request_headers":{},"upstream_headers":["X-User-ID"]},"proxy-rewrite":{"uri":"/echo","use_real_request_uri_unsafe":false}},"upstream_id":"u1","uri":"/ping","priority":0,"id":"3","update_time":1751826356},"has_domain":false,"clean_handlers":{},"modifiedIndex":2935,"key":"/apisix/routes/3","createdIndex":4}, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *19 [lua] balancer.lua:196: pick_server(): ctx: {"real_curr_req_matched_path":"/ping","plugins":"table: 0x76659775a658","curr_req_matched":"table: 0x7665977bb610","conf_version":2935,"matched_upstream":"table: 0x766599661220","conf_type":"route","upstream_version":"2930#table: 0x766599661220#","upstream_conf":{"create_time":1751435139,"type":"roundrobin","id":"u1","update_time":1751826356,"hash_on":"vars","pass_host":"pass","scheme":"http","nodes":"table: 0x766597779958","parent":{"value":"table: 0x766599661220","has_domain":false,"clean_handlers":{},"modifiedIndex":2930,"key":"/apisix/upstreams/u1","createdIndex":885},"original_nodes":[{"port":1984,"weight":1,"host":"127.0.0.1"}],"nodes_ref":[{"port":1984,"priority":0,"weight":1,"host":"127.0.0.1"}]},"conf_id":"3","route_id":"3","upstream_key":"u1","var":{"_request":"cdata<void *>: 0x567d1728ed50","_ctx":{"real_curr_req_matched_path":"/ping","plugins":[{"check_schema":"function: 0x7665a8bedb70","priority":2002,"version":0.1,"access":"function: 0x7665a8bedb08","name":"forward-auth","schema":{"required":["uri"],"$comment":"this is a mark for our injected plugin schema","type":"object","properties":{"client_headers":{"type":"array","default":{},"description":"authorization response header that will be sent tothe client when authorizing failed","items":{"type":"string"}},"status_on_error":{"type":"integer","default":403,"minimum":200,"maximum":599},"allow_degradation":{"type":"boolean","default":false},"keepalive_pool":{"default":5,"type":"integer","minimum":1},"keepalive_timeout":{"default":60000,"type":"integer","minimum":1000},"ssl_verify":{"type":"boolean","default":true},"timeout":{"type":"integer","maximum":60000,"default":60000,"minimum":1,"description":"timeout in milliseconds"},"keepalive":{"type":"boolean","default":true},"_meta":{"additionalProperties":false,"type":"object","properties":{"pre_function":{"description":"function to be executed in each phase before execution of plugins. The pre_function will have access to two arguments: `conf` and `ctx`.","type":"string"},"disable":{"type":"boolean"},"error_response":{"oneOf":[{"type":"string"},{"type":"object"}]},"priority":{"description":"priority of plugins by customized order","type":"integer"},"filter":{"description":"filter determines whether the plugin needs to be executed at runtime","type":"array"}}},"request_method":{"enum":["GET","POST"],"default":"GET","description":"the method for client to request the authorization service","type":"string"},"uri":{"type":"string"},"request_headers":{"type":"array","default":{},"description":"client request header that will be sent to the authorization service","items":{"type":"string"}},"upstream_headers":{"type":"array","default":{},"description":"authorization response header that will be sent to the upstream","items":{"type":"string"}}}}},"table: 0x76659780e598",{"check_schema":"function: 0x76659743c328","priority":1008,"rewrite":"function: 0x766597436020","version":0.1,"name":"proxy-rewrite","schema":{"type":"object","$comment":"this is a mark for our injected plugin schema","minProperties":1,"properties":{"_meta":"table: 0x7665999443e8","headers":{"description":"new headers for request","oneOf":[{"additionalProperties":false,"minProperties":1,"properties":{"remove":{"minItems":1,"type":"array","items":{"type":"string","pattern":"^[^:]+$"}},"add":{"patternProperties":{"^[^:]+$":{"oneOf":[{"type":"string"},{"type":"number"}]}},"type":"object","minProperties":1},"set":{"patternProperties":{"^[^:]+$":{"oneOf":[{"type":"string"},{"type":"number"}]}},"type":"object","minProperties":1}},"type":"object"},{"patternProperties":{"^[^:]+$":{"oneOf":[{"type":"string"},{"type":"number"}]}},"type":"object","minProperties":1}]},"regex_uri":{"description":"new uri that substitute from client uri for upstream, lower priority than uri property","minItems":2,"type":"array","items":{"description":"regex uri","type":"string"}},"uri":{"description":"new uri for upstream","minLength":1,"maxLength":4096,"type":"string","pattern":"^\\/.*"},"metho
2025/07/06 23:56:00 [info] 190999#190999: *19 [lua] balancer.lua:384: run(): proxy request to 127.0.0.1:1984 while connecting to upstream, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *43 [lua] ai.lua:79: match(): route match mode: ai_match, client: 127.0.0.1, server: localhost, request: "POST /echo HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *43 [lua] ai.lua:82: match(): route cache key: /echo, client: 127.0.0.1, server: localhost, request: "POST /echo HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *43 [lua] radixtree_host_uri.lua:161: orig_router_http_matching(): route match mode: radixtree_host_uri, client: 127.0.0.1, server: localhost, request: "POST /echo HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [info] 190999#190999: *43 [lua] init.lua:660: http_access_phase(): matched route: {"orig_modifiedIndex":2932,"value":{"create_time":1751435139,"status":1,"id":"echo","uri":"/echo","priority":0,"plugins":{"serverless-pre-function":{"phase":"rewrite","functions":["return function (conf, ctx)\n                                        local core = require(\"apisix.core\");\n                                        if core.request.get_method() == \"POST\" then\n                                            local body = core.request.get_body()\n                                            local headers = core.request.headers(ctx)\n                                            local response_data = {\n                                                headers = headers,\n                                                body = body\n                                            }\n                                            core.response.exit(200, response_data);\n                                        else\n                                            core.response.exit(200, core.request.headers(ctx));\n                                        end\n                                    end"]}},"update_time":1751826356},"has_domain":false,"clean_handlers":{},"modifiedIndex":2932,"key":"/apisix/routes/echo","createdIndex":887}, client: 127.0.0.1, server: localhost, request: "POST /echo HTTP/1.1", host: "localhost"
2025/07/06 23:56:00 [warn] 190999#190999: *43 [lua] request.lua:303: get_body(): reading started...HTTP/1.1, client: 127.0.0.1, server: localhost, request: "POST /echo HTTP/1.1", host: "localhost"



2025/07/06 23:56:10 [info] 190999#190999: *19 epoll_wait() reported that client prematurely closed connection, so upstream connection is closed too while sending request to upstream, client: 127.0.0.1, server: localhost, request: "POST /ping HTTP/1.1", upstream: "http://127.0.0.1:1984/echo", host: "localhost"
2025/07/06 23:56:10 [info] 190999#190999: *43 client prematurely closed connection, client: 127.0.0.1, server: localhost, request: "POST /echo HTTP/1.1", host: "localhost"
2025/07/06 23:56:10 [info] 190999#190999: *41 client 127.0.0.1 closed keepalive connection
2025/07/06 23:56:10 [notice] 190998#190998: signal 15 (SIGTERM) received from 190911, exiting
2025/07/06 23:56:10 [notice] 191000#191000: exiting
2025/07/06 23:56:10 [notice] 190999#190999: exiting
2025/07/06 23:56:10 [notice] 191000#191000: cleanup wasm vm: wasmtime
2025/07/06 23:56:10 [notice] 190999#190999: cleanup wasm vm: wasmtime
2025/07/06 23:56:10 [notice] 191000#191000: exit
2025/07/06 23:56:10 [notice] 190999#190999: exit
2025/07/06 23:56:10 [notice] 190998#190998: signal 17 (SIGCHLD) received from 191000
2025/07/06 23:56:10 [notice] 190998#190998: privileged agent process 191000 exited with code 0
2025/07/06 23:56:10 [notice] 190998#190998: worker process 190999 exited with code 0
2025/07/06 23:56:10 [notice] 190998#190998: exit
2025/07/06 23:56:10 [notice] 190998#190998: cleanup wasm vm: wasmtime

```
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
